### PR TITLE
Feature: Remove BDRS Configuration from helm chart

### DIFF
--- a/charts/factoryx-connector-memory/README.md
+++ b/charts/factoryx-connector-memory/README.md
@@ -33,9 +33,6 @@ Be sure to provide the following configuration entries to your Tractus-X EDC Hel
 - `iatp.sts.oauth.client.secret_alias`: alias under which you saved your DIM client secret in the vault
 - `iatp.sts.dim.url`: the base URL for DIM
 
-In addition, in order to map BPNs to DIDs, a new service is required, called the BPN-DID Resolution Service, which
-must be configured:
-- `controlplane.bdrs.server.url`: base URL of the BPN-DID Resolution Service ("BDRS")
 
 ### Launching the application
 
@@ -79,8 +76,6 @@ helm install my-release tractusx-edc/tractusx-connector-memory --version 0.8.0-r
 | runtime.autoscaling.minReplicas | int | `1` | Minimal replicas if resource consumption falls below resource threshholds |
 | runtime.autoscaling.targetCPUUtilizationPercentage | int | `80` | targetAverageUtilization of cpu provided to a pod |
 | runtime.autoscaling.targetMemoryUtilizationPercentage | int | `80` | targetAverageUtilization of memory provided to a pod |
-| runtime.bdrs.cache_validity_seconds | int | `600` | Time that a cached BPN/DID resolution map is valid in seconds, default is 600 seconds (10 min) |
-| runtime.bdrs.server.url | string | `nil` | URL of the BPN/DID Resolution Service |
 | runtime.catalog | object | `{"crawler":{"initialDelay":null,"num":null,"period":null,"targetsFile":null},"enabled":false}` | configuration for the built-in federated catalog crawler |
 | runtime.catalog.crawler.initialDelay | string | `nil` | Initial delay for the crawling to start. Leave blank for a random delay |
 | runtime.catalog.crawler.num | string | `nil` | Number of desired crawlers. Final number might be different, based on number of crawl targets |

--- a/charts/factoryx-connector-memory/README.md.gotmpl
+++ b/charts/factoryx-connector-memory/README.md.gotmpl
@@ -32,9 +32,6 @@ Be sure to provide the following configuration entries to your Tractus-X EDC Hel
 - `iatp.sts.oauth.client.secret_alias`: alias under which you saved your DIM client secret in the vault
 - `iatp.sts.dim.url`: the base URL for DIM
 
-In addition, in order to map BPNs to DIDs, a new service is required, called the BPN-DID Resolution Service, which
-must be configured:
-- `controlplane.bdrs.server.url`: base URL of the BPN-DID Resolution Service ("BDRS")
 
 ### Launching the application
 

--- a/charts/factoryx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/factoryx-connector-memory/templates/deployment-runtime.yaml
@@ -234,16 +234,6 @@ spec:
               value: {{ $issuer | quote }}
             {{- end }}
 
-            #################
-            ## BDRS CLIENT ##
-            #################
-
-            - name: "TX_IAM_IATP_BDRS_SERVER_URL"
-              value: {{ .Values.runtime.bdrs.server.url | required ".Values.runtime.bdrs.server.url is required" | quote }}
-            {{- if .Values.runtime.bdrs.cache_validity_seconds }}
-            - name: "TX_IAM_IATP_BDRS_CACHE_VALIDITY"
-              value: {{ .Values.runtime.bdrs.cache_validity_seconds | quote}}
-            {{- end}}
 
             ################
             ## DATA PLANE ##

--- a/charts/factoryx-connector-memory/values.yaml
+++ b/charts/factoryx-connector-memory/values.yaml
@@ -171,13 +171,6 @@ runtime:
       # -- Alias under which the public key (JWK or PEM format) is stored in the vault, that belongs to the private key which was referred to at `dataplane.token.signer.privatekey_alias`
       publickey_alias:
 
-  bdrs:
-    # -- Time that a cached BPN/DID resolution map is valid in seconds, default is 600 seconds (10 min)
-    cache_validity_seconds: 600
-    server:
-      # -- URL of the BPN/DID Resolution Service
-      url:
-
   # -- configuration for the built-in federated catalog crawler
   catalog:
     # -- Flag to globally enable/disable the FC feature

--- a/charts/factoryx-connector/README.md
+++ b/charts/factoryx-connector/README.md
@@ -37,9 +37,6 @@ Be sure to provide the following configuration entries to your Tractus-X EDC Hel
 - `iatp.sts.oauth.client.secret_alias`: alias under which you saved your DIM client secret in the vault
 - `iatp.sts.dim.url`: the base URL for DIM
 
-In addition, in order to map BPNs to DIDs, a new service is required, called the BPN-DID Resolution Service, which
-must be configured:
-- `controlplane.bdrs.server.url`: base URL of the BPN-DID Resolution Service ("BDRS")
 
 ### Launching the application
 
@@ -76,8 +73,6 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.8.0-rc4 \
 | controlplane.autoscaling.minReplicas | int | `1` | Minimal replicas if resource consumption falls below resource threshholds |
 | controlplane.autoscaling.targetCPUUtilizationPercentage | int | `80` | targetAverageUtilization of cpu provided to a pod |
 | controlplane.autoscaling.targetMemoryUtilizationPercentage | int | `80` | targetAverageUtilization of memory provided to a pod |
-| controlplane.bdrs.cache_validity_seconds | int | `600` | Time that a cached BPN/DID resolution map is valid in seconds, default is 600 seconds (10 min) |
-| controlplane.bdrs.server.url | string | `nil` | URL of the BPN/DID Resolution Service |
 | controlplane.catalog | object | `{"crawler":{"initialDelay":null,"num":null,"period":null,"targetsFile":null},"enabled":false}` | configuration for the built-in federated catalog crawler |
 | controlplane.catalog.crawler.initialDelay | string | `nil` | Initial delay for the crawling to start. Leave blank for a random delay |
 | controlplane.catalog.crawler.num | string | `nil` | Number of desired crawlers. Final number might be different, based on number of crawl targets |

--- a/charts/factoryx-connector/README.md.gotmpl
+++ b/charts/factoryx-connector/README.md.gotmpl
@@ -32,9 +32,6 @@ Be sure to provide the following configuration entries to your Tractus-X EDC Hel
 - `iatp.sts.oauth.client.secret_alias`: alias under which you saved your DIM client secret in the vault
 - `iatp.sts.dim.url`: the base URL for DIM
 
-In addition, in order to map BPNs to DIDs, a new service is required, called the BPN-DID Resolution Service, which
-must be configured:
-- `controlplane.bdrs.server.url`: base URL of the BPN-DID Resolution Service ("BDRS")
 
 ### Launching the application
 

--- a/charts/factoryx-connector/templates/deployment-controlplane.yaml
+++ b/charts/factoryx-connector/templates/deployment-controlplane.yaml
@@ -233,16 +233,6 @@ spec:
               value: {{ $issuer | quote }}
             {{- end }}
 
-            #################
-            ## BDRS CLIENT ##
-            #################
-
-            - name: "TX_IAM_IATP_BDRS_SERVER_URL"
-              value: {{ .Values.controlplane.bdrs.server.url | required ".Values.controlplane.bdrs.server.url is required" | quote }}
-            {{- if .Values.controlplane.bdrs.cache_validity_seconds }}
-            - name: "TX_IAM_IATP_BDRS_CACHE_VALIDITY"
-              value: {{ .Values.controlplane.bdrs.cache_validity_seconds | quote}}
-            {{- end}}
 
             ###########
             ## VAULT ##

--- a/charts/factoryx-connector/values.yaml
+++ b/charts/factoryx-connector/values.yaml
@@ -155,13 +155,6 @@ controlplane:
       # -- authentication key, must be attached to each request as `X-Api-Key` header
       authKey: "password"
 
-  bdrs:
-    # -- Time that a cached BPN/DID resolution map is valid in seconds, default is 600 seconds (10 min)
-    cache_validity_seconds: 600
-    server:
-      # -- URL of the BPN/DID Resolution Service
-      url:
-
   # -- configuration for the built-in federated catalog crawler
   catalog:
     # -- Flag to globally enable/disable the FC feature


### PR DESCRIPTION
## Description
- Remove bdrs configuration from `values.yaml`
- Remove bdrs configuration usage from helm templates.
- Update readme template
- Re-generate readme from template

Closes #22 
