### PR TITLE
chore: collapse terms into fx-policy namespace.

### DIFF
--- a/edc-extensions/fx-json-ld-core/src/main/java/org/factoryx/edc/jsonld/JsonLdExtension.java
+++ b/edc-extensions/fx-json-ld-core/src/main/java/org/factoryx/edc/jsonld/JsonLdExtension.java
@@ -35,12 +35,9 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static org.factoryx.edc.edr.spi.CoreConstants.FX_CONTEXT;
-import static org.factoryx.edc.edr.spi.CoreConstants.FX_NAMESPACE;
 import static org.factoryx.edc.edr.spi.CoreConstants.FX_POLICY_CONTEXT;
 import static org.factoryx.edc.edr.spi.CoreConstants.FX_POLICY_NS;
 import static org.factoryx.edc.edr.spi.CoreConstants.FX_POLICY_PREFIX;
-import static org.factoryx.edc.edr.spi.CoreConstants.FX_PREFIX;
 
 /**
  *  Provides JSON-LD structure for Factory-X policies.
@@ -49,7 +46,6 @@ public class JsonLdExtension implements ServiceExtension {
 
     private static final String PREFIX = "document" + File.separator;
     private static final Map<String, String> FILES = Map.of(
-            FX_CONTEXT, PREFIX + "fx-v1.jsonld",
             FX_POLICY_CONTEXT, PREFIX + "fx-policy-v1.jsonld");
 
     @Inject
@@ -60,7 +56,6 @@ public class JsonLdExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        jsonLdService.registerNamespace(FX_PREFIX, FX_NAMESPACE);
         jsonLdService.registerNamespace(FX_POLICY_PREFIX, FX_POLICY_NS);
         FILES.entrySet().stream().map(this::mapToFile)
                 .forEach(result -> result.onSuccess(entry -> jsonLdService.registerCachedDocument(entry.getKey(), entry.getValue().toURI()))

--- a/edc-extensions/fx-json-ld-core/src/main/resources/document/fx-policy-v1.jsonld
+++ b/edc-extensions/fx-json-ld-core/src/main/resources/document/fx-policy-v1.jsonld
@@ -6,6 +6,7 @@
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "fx-policy": "https://w3id.org/factoryx/policy/",
     "Membership": "fx-policy:Membership",
-    "CertificationType": "fx-policy:CertificationType"
+    "CertificationType": "fx-policy:CertificationType",
+    "BusinessPartnerDID": "fx-policy:BusinessPartnerDID"
   }
 }

--- a/edc-extensions/fx-json-ld-core/src/main/resources/document/fx-v1.jsonld
+++ b/edc-extensions/fx-json-ld-core/src/main/resources/document/fx-v1.jsonld
@@ -1,8 +1,0 @@
-{
-  "@context": {
-    "@version": 1.1,
-    "@protected": true,
-    "fx": "https://w3id.org/factoryx/v0.0.1/ns/",
-    "BusinessPartnerDID": "fx:BusinessPartnerDID"
-  }
-}


### PR DESCRIPTION
This collapses the namespaces into a single context object. A lot of other issues (like a separate fx-auth namespace) were fixed beforehand.