### PR TITLE
feat: make vaultseed job optional in helm chart

### DIFF
--- a/charts/factoryx-connector/templates/job-vaultseed.yaml
+++ b/charts/factoryx-connector/templates/job-vaultseed.yaml
@@ -16,6 +16,8 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #################################################################################
+
+{{ if eq (.Values.vaultseed.enabled | toString) "true" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -84,3 +86,5 @@ spec:
         - name: keypair
           emptyDir: {}
       restartPolicy: OnFailure
+---
+{{- end }}

--- a/charts/factoryx-connector/values.yaml
+++ b/charts/factoryx-connector/values.yaml
@@ -611,6 +611,8 @@ vault:
 
 # -- Configuration for Vault Seed Job
 vaultseed:
+  # -- places a keypair in the vault named alias-for-public-key and alias-for-private-key. If enabled, set dataplane.token.signer.privatekey_alias and dataplane.token.verifier.publickey_alias accordingly.
+  enabled: false
   # -- Docker image Configuration for Vault Seed Job
   image:
     # -- docker image/tag defaults to image/tag used in the vault helm chart in Chart dependencies
@@ -640,7 +642,7 @@ vaultseed:
       tag: "3.5.0"
 
 networkPolicy:
-  # -- If `true` network policy will be created to restrict access to control- and dataplane
+  # -- If `true` network policy will be created to restrict access to control- and dataplane.token.signer.privatekey
   enabled: false
   # -- Configuration of the controlplane component
   controlplane:


### PR DESCRIPTION
## WHAT

This PR makes the vault seed job optional

## WHY

I'm sure there's cases when this is either not required or the keys are generated out of band

## FURTHER NOTES

tested this locally via helm template.

Closes #181