### PR TITLE
fix: Allow `$` into the vault secret  key / value pair

### DIFF
--- a/charts/factoryx-connector/templates/job-vaultseed.yaml
+++ b/charts/factoryx-connector/templates/job-vaultseed.yaml
@@ -60,7 +60,7 @@ spec:
               vault kv put secret/{{ .Values.dataplane.token.verifier.publickey_alias }} content=@/keypair/dataplane_public_key.pem
               {{- range .Values.vaultseed.secrets }}
               {{- if .value }}
-              vault kv put secret/{{ .key }} content={{ .value | quote }}
+              vault kv put secret/'{{ .key }}' content='{{ .value }}'
               {{- else if .valueFrom }}
               {{- $fileContent := $.Files.Get .valueFrom }}
               {{- if $fileContent }}


### PR DESCRIPTION
## WHAT
- Allow `$` into vault secret's key / value

## WHY
- Some vault secrets may contain `$`, but bash script treat it as a variable

## FURTHER NOTES

Closes #183 
