### PR TITLE
fix: Fix Deployment Runtime memory docker image in charts

### DIFF
--- a/charts/factoryx-connector-memory/README.md
+++ b/charts/factoryx-connector-memory/README.md
@@ -1,6 +1,9 @@
 # factoryx-connector-memory
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
+
+
+
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square) 
 
 A Helm chart for Factory-X Eclipse Data Space Connector based on memory. Please only use this for development or testing purposes, never in production workloads!
 
@@ -21,6 +24,7 @@ A Helm chart for Factory-X Eclipse Data Space Connector based on memory. Please 
   is out of scope of this document. But by default, Factory-X EDC expects to find the secret under `secret/client-secret`. The alias must be configured
   using the `iatp.sts.oauth.client.secret_alias` Helm value.
 
+
 ### Configure the chart
 
 Be sure to provide the following configuration entries to your Factory-X EDC Helm chart:
@@ -28,6 +32,7 @@ Be sure to provide the following configuration entries to your Factory-X EDC Hel
 - `iatp.sts.oauth.client.id`: the client ID of your tenant in DIM
 - `iatp.sts.oauth.client.secret_alias`: alias under which you saved your DIM client secret in the vault
 - `iatp.sts.dim.url`: the base URL for DIM
+
 
 ### Launching the application
 
@@ -42,9 +47,13 @@ helm install my-release factory-x-contributions/factoryx-connector-memory --vers
      --set vault.secrets="client-secret:$YOUR_CLIENT_SECRET"
 ```
 
+
+
 ## Source Code
 
 * <https://github.com/factory-x-contributions/factoryx-edc/tree/main/charts/factoryx-connector-memory>
+
+
 
 ## Values
 

--- a/charts/factoryx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/factoryx-connector-memory/templates/deployment-runtime.yaml
@@ -64,7 +64,7 @@ spec:
           {{- if .Values.runtime.image.repository }}
           image: "{{ .Values.runtime.image.repository }}:{{ .Values.runtime.image.tag | default .Chart.AppVersion }}"
           {{- else }}
-          image: "tractusx/edc-runtime-memory:{{ .Values.runtime.image.tag | default .Chart.AppVersion }}"
+          image: "factory-x-contributions/edc-runtime-memory:{{ .Values.runtime.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.runtime.image.pullPolicy }}
           command:
@@ -95,7 +95,7 @@ spec:
           {{- if .Values.runtime.image.repository }}
           image: "{{ .Values.runtime.image.repository }}:{{ .Values.runtime.image.tag | default .Chart.AppVersion }}"
           {{- else }}
-          image: "tractusx/edc-runtime-memory:{{ .Values.runtime.image.tag | default .Chart.AppVersion }}"
+          image: "factory-x-contributions/edc-runtime-memory:{{ .Values.runtime.image.tag | default .Chart.AppVersion }}"
           {{- end }}
 
           imagePullPolicy: {{ .Values.runtime.image.pullPolicy }}

--- a/charts/factoryx-connector/README.md
+++ b/charts/factoryx-connector/README.md
@@ -1,11 +1,15 @@
 # factoryx-connector
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
+
+
+
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square) 
 
 A Helm chart for Factory-X Eclipse Data Space Connector. The connector deployment consists of two runtimes of a
 Control Plane and a Data Plane. Note that _no_ external dependencies such as a PostgreSQL database and HashiCorp Vault are included.
 
 This chart is intended for use with an _existing_ PostgreSQL database and an _existing_ HashiCorp Vault.
+
 
 **Homepage:** <https://github.com/factory-x-contributions/factoryx-edc/tree/main/charts/factoryx-connector>
 
@@ -24,6 +28,7 @@ This chart is intended for use with an _existing_ PostgreSQL database and an _ex
   is out of scope of this document. But by default, Factory-X EDC expects to find the secret under `secret/client-secret`. The alias must be configured
   using the `iatp.sts.oauth.client.secret_alias` Helm value.
 
+
 ### Configure the chart
 
 Be sure to provide the following configuration entries to your Factory-X EDC Helm chart:
@@ -31,6 +36,7 @@ Be sure to provide the following configuration entries to your Factory-X EDC Hel
 - `iatp.sts.oauth.client.id`: the client ID of your tenant in DIM
 - `iatp.sts.oauth.client.secret_alias`: alias under which you saved your DIM client secret in the vault
 - `iatp.sts.dim.url`: the base URL for DIM
+
 
 ### Launching the application
 
@@ -43,6 +49,8 @@ helm repo add factoryx-dev https://factory-x-contributions.github.io/charts/dev
 helm install my-release factory-x-contributions/factoryx-connector --version 0.1.1 \
      -f <path-to>/tractusx-connector-test.yaml
 ```
+
+
 
 ## Source Code
 


### PR DESCRIPTION
## WHAT

- Update deployment runtime docker image default value
- Update helm charts docs

## WHY

Currently, it points to another docker image which may not exist.

## FURTHER NOTES

Closes #192
