### PR TITLE
fix: Run Snapshot build after Factory-X CI Build

### DIFF
--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -24,7 +24,7 @@ run-name: "Publish new snapshot from ${{github.ref_name}}"
 
 on:
   workflow_run:
-    workflows: [ "CI for FactoryX Backend" ]
+    workflows: [ "Factory-X Build" ]
     branches:
       - main
       - bugfix/*


### PR DESCRIPTION
## WHAT

- Trigger Snapshot Release after CI Build

## WHY


## FURTHER NOTES


Closes #202 
