### PR TITLE
fix: Remove Duplicate BPN Validation API lib from tractusX

### DIFF
--- a/charts/factoryx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/factoryx-connector-memory/templates/deployment-runtime.yaml
@@ -154,10 +154,10 @@ spec:
             # API #
             #######
             {{- if .Values.runtime.endpoints.management.jwksUrl }}
-            - name: "EDC_API_AUTH_DAC_KEY_URL"
+            - name: "WEB_HTTP_MANAGEMENT_AUTH_DAC_KEY_URL"
               value: {{ .Values.runtime.endpoints.management.jwksUrl | quote}}
             {{- else }}
-            - name: "EDC_API_AUTH_KEY"
+            - name: "WEB_HTTP_MANAGEMENT_AUTH_KEY"
               value: {{ .Values.runtime.endpoints.management.authKey | required ".Values.controlplane.endpoints.management.authKey is required" | quote }}
             {{- end }}
 

--- a/charts/factoryx-connector/templates/deployment-controlplane.yaml
+++ b/charts/factoryx-connector/templates/deployment-controlplane.yaml
@@ -156,10 +156,10 @@ spec:
             #######
 
           {{- if .Values.controlplane.endpoints.management.jwksUrl }}
-            - name: "EDC_API_AUTH_DAC_KEY_URL"
+            - name: "WEB.HTTP.MANAGEMENT.AUTH_DAC_KEY_URL"
               value: {{ .Values.controlplane.endpoints.management.jwksUrl | quote }}
           {{- else }}
-            - name: "EDC_API_AUTH_KEY"
+            - name: "WEB_HTTP_MANAGEMENT_AUTH_KEY"
               value: {{ .Values.controlplane.endpoints.management.authKey | required ".Values.controlplane.endpoints.management.authKey is required" | quote }}
           {{- end }}
             - name: "WEB_HTTP_DEFAULT_PORT"

--- a/edc-controlplane/edc-controlplane-base/build.gradle.kts
+++ b/edc-controlplane/edc-controlplane-base/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
         exclude("org.eclipse.tractusx.edc", "tx-dcp")
         exclude("org.eclipse.tractusx.edc", "bdrs-client")
         exclude("org.eclipse.tractusx.edc", "data-flow-properties-provider")
-        exclude("org.eclipse.tractusx.edc", "bpn-validation-core")
+        exclude("org.eclipse.tractusx.edc", "bpn-validation")
     }
 
     // fx-edc extensions


### PR DESCRIPTION
## WHAT

- Remove duplicate bpn-validation api from classpath

## WHY
- Same path getting exposed as API via two different endpoints, causing startup error.

## FURTHER NOTES

Closes #193 