### PR TITLE
feat: Implement mqtt data endpoint lib

### DIFF
--- a/edc-extensions/mqtt/mqtt-data-endpoint/build.gradle.kts
+++ b/edc-extensions/mqtt/mqtt-data-endpoint/build.gradle.kts
@@ -17,17 +17,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-package org.factoryx.edc.mqtt.data.endpoint.spi;
+plugins {
+    `java-library`
+}
 
-import org.eclipse.edc.spi.result.Result;
+dependencies {
 
-public interface EndpointTypeParser {
+    api(libs.edc.spi.core)
+    implementation(project(":spi:mqtt:mqtt-data-endpoint-spi"))
 
-    /**
-     * Parse the {@link EndpointType}.
-     *
-     * @param endpointType the transfer type string representation.
-     * @return the {@link EndpointType}, failure if the operation failed.
-     */
-    Result<EndpointType> parse(String endpointType);
+    testImplementation(libs.edc.junit)
 }

--- a/edc-extensions/mqtt/mqtt-data-endpoint/src/main/java/org/factoryx/edc/mqtt/data/endpoint/EndpointTypeExtension.java
+++ b/edc-extensions/mqtt/mqtt-data-endpoint/src/main/java/org/factoryx/edc/mqtt/data/endpoint/EndpointTypeExtension.java
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (c) 2025 SAP SE
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.factoryx.edc.mqtt.data.endpoint;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.factoryx.edc.mqtt.data.endpoint.parser.EndpointTypeParserImpl;
+import org.factoryx.edc.mqtt.data.endpoint.parser.spi.EndpointTypeParser;
+
+public class EndpointTypeExtension implements ServiceExtension {
+
+    @Inject
+    private Monitor monitor;
+
+    @Provider(isDefault = true)
+    public EndpointTypeParser endpointTypeParser() {
+        return new EndpointTypeParserImpl(monitor);
+    }
+}

--- a/edc-extensions/mqtt/mqtt-data-endpoint/src/main/java/org/factoryx/edc/mqtt/data/endpoint/parser/EndpointTypeParserImpl.java
+++ b/edc-extensions/mqtt/mqtt-data-endpoint/src/main/java/org/factoryx/edc/mqtt/data/endpoint/parser/EndpointTypeParserImpl.java
@@ -1,0 +1,64 @@
+/********************************************************************************
+ * Copyright (c) 2025 SAP SE
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.factoryx.edc.mqtt.data.endpoint.parser;
+
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.factoryx.edc.mqtt.data.endpoint.parser.spi.EndpointTypeParser;
+import org.factoryx.edc.mqtt.data.endpoint.spi.EndpointType;
+import org.factoryx.edc.mqtt.data.endpoint.spi.EndpointType.AuthType;
+import org.factoryx.edc.mqtt.data.endpoint.spi.EndpointType.DestinationType;
+import org.factoryx.edc.mqtt.data.endpoint.spi.EndpointType.Protocol;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public class EndpointTypeParserImpl implements EndpointTypeParser {
+
+    private final Monitor monitor;
+
+    public EndpointTypeParserImpl(Monitor monitor) {
+        this.monitor = monitor;
+    }
+
+    @Override
+    public Result<EndpointType> parse(String endpointType) {
+        Optional<Result<EndpointType>> parsed = Optional.ofNullable(endpointType)
+                .map(type -> type.split("-"))
+                .filter(tokens -> tokens.length == 3)
+                .map(this::parseEndpointType);
+
+        return parsed.orElse(Result.failure("Failed to parse endpoint type %s".formatted(endpointType)));
+    }
+
+    protected Result<EndpointType> parseEndpointType(String[] tokens) {
+
+        try {
+            DestinationType destinationType = DestinationType.valueOf(tokens[0].toUpperCase());
+            Protocol protocol = Protocol.valueOf(tokens[1].toUpperCase());
+            AuthType authType = AuthType.valueOf(tokens[2].toUpperCase());
+            return Result.success(new EndpointType(destinationType, protocol, authType));
+        } catch (Exception ex) {
+            String msg = "Failed to parse endpoint type %s".formatted(Arrays.toString(tokens));
+            monitor.warning(msg, ex);
+            return Result.failure(msg);
+        }
+    }
+}

--- a/edc-extensions/mqtt/mqtt-data-endpoint/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/edc-extensions/mqtt/mqtt-data-endpoint/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,20 @@
+#################################################################################
+#  Copyright (c) 2025 SAP SE
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+org.factoryx.edc.mqtt.data.endpoint.EndpointTypeExtension

--- a/edc-extensions/mqtt/mqtt-data-endpoint/src/test/java/org/factoryx/edc/mqtt/data/endpoint/EndpointTypeExtensionTest.java
+++ b/edc-extensions/mqtt/mqtt-data-endpoint/src/test/java/org/factoryx/edc/mqtt/data/endpoint/EndpointTypeExtensionTest.java
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2025 SAP SE
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.factoryx.edc.mqtt.data.endpoint;
+
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.factoryx.edc.mqtt.data.endpoint.parser.spi.EndpointTypeParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+
+@ExtendWith(DependencyInjectionExtension.class)
+class EndpointTypeExtensionTest {
+
+    private final Monitor monitor = mock();
+
+    @BeforeEach
+    void setup(ServiceExtensionContext context) {
+        context.registerService(Monitor.class, monitor);
+    }
+
+    @Test
+    void testProviders(ServiceExtensionContext context, EndpointTypeExtension extension) {
+
+        assertThat(extension.endpointTypeParser()).isInstanceOf(EndpointTypeParser.class);
+    }
+}

--- a/edc-extensions/mqtt/mqtt-data-endpoint/src/test/java/org/factoryx/edc/mqtt/data/endpoint/parser/EndpointTypeParserImplTest.java
+++ b/edc-extensions/mqtt/mqtt-data-endpoint/src/test/java/org/factoryx/edc/mqtt/data/endpoint/parser/EndpointTypeParserImplTest.java
@@ -1,0 +1,100 @@
+/********************************************************************************
+ * Copyright (c) 2025 SAP SE
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.factoryx.edc.mqtt.data.endpoint.parser;
+
+import org.eclipse.edc.spi.monitor.ConsoleMonitor;
+import org.factoryx.edc.mqtt.data.endpoint.parser.spi.EndpointTypeParser;
+import org.factoryx.edc.mqtt.data.endpoint.spi.EndpointType.AuthType;
+import org.factoryx.edc.mqtt.data.endpoint.spi.EndpointType.DestinationType;
+import org.factoryx.edc.mqtt.data.endpoint.spi.EndpointType.Protocol;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+class EndpointTypeParserImplTest {
+
+    private final EndpointTypeParser parser = new EndpointTypeParserImpl(new ConsoleMonitor());
+
+    @Test
+    void shouldExtractMqttTcpBasic() {
+        var result = parser.parse("MQTT-TCP-BASIC");
+
+        assertThat(result).isSucceeded().satisfies(type -> {
+            assertThat(type.destinationType()).isEqualTo(DestinationType.MQTT);
+            assertThat(type.protocol()).isEqualTo(Protocol.TCP);
+            assertThat(type.authType()).isEqualTo(AuthType.BASIC);
+        });
+    }
+
+    @Test
+    void shouldExtractMqttTcpOauth2() {
+        var result = parser.parse("mqtt-tcp-oauth2");
+
+        assertThat(result).isSucceeded().satisfies(type -> {
+            assertThat(type.destinationType()).isEqualTo(DestinationType.MQTT);
+            assertThat(type.protocol()).isEqualTo(Protocol.TCP);
+            assertThat(type.authType()).isEqualTo(AuthType.OAUTH2);
+        });
+    }
+
+    @Test
+    void shouldExtractMqttWssBasic() {
+        var result = parser.parse("MQTT-WSS-BASIC");
+
+        assertThat(result).isSucceeded().satisfies(type -> {
+            assertThat(type.destinationType()).isEqualTo(DestinationType.MQTT);
+            assertThat(type.protocol()).isEqualTo(Protocol.WSS);
+            assertThat(type.authType()).isEqualTo(AuthType.BASIC);
+        });
+    }
+
+    @Test
+    void shouldExtractMqttWssOauth2() {
+        var result = parser.parse("mqtt-wss-oauth2");
+
+        assertThat(result).isSucceeded().satisfies(type -> {
+            assertThat(type.destinationType()).isEqualTo(DestinationType.MQTT);
+            assertThat(type.protocol()).isEqualTo(Protocol.WSS);
+            assertThat(type.authType()).isEqualTo(AuthType.OAUTH2);
+        });
+    }
+
+    @Test
+    void shouldFailAuthTypeMissing() {
+        var result = parser.parse("mqtt-TCP");
+
+        assertThat(result).isFailed();
+    }
+
+    @Test
+    void shouldFailInvalidDestinationType() {
+        var result = parser.parse("KAFKA-TCP-BASIC");
+
+        assertThat(result).isFailed();
+    }
+
+    @Test
+    void shouldFailInvalidTokens() {
+        var result = parser.parse("mqtt-http-oauth");
+
+        assertThat(result).isFailed();
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,6 +41,7 @@ include(":edc-extensions:contract-validation")
 include(":edc-extensions:http-tls:http-tls-client")
 include(":edc-extensions:http-tls:http-tls-client-lib")
 include(":edc-extensions:http-tls:data-plane-http-tls")
+include(":edc-extensions:mqtt:mqtt-data-endpoint")
 
 // modules for controlplane artifacts
 include(":edc-controlplane")

--- a/spi/mqtt/mqtt-data-endpoint-spi/src/main/java/org/factoryx/edc/mqtt/data/endpoint/parser/spi/EndpointTypeParser.java
+++ b/spi/mqtt/mqtt-data-endpoint-spi/src/main/java/org/factoryx/edc/mqtt/data/endpoint/parser/spi/EndpointTypeParser.java
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2025 SAP SE
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.factoryx.edc.mqtt.data.endpoint.parser.spi;
+
+import org.eclipse.edc.spi.result.Result;
+import org.factoryx.edc.mqtt.data.endpoint.spi.EndpointType;
+
+public interface EndpointTypeParser {
+
+    /**
+     * Parse the {@link EndpointType}.
+     *
+     * @param endpointType the transfer type string representation.
+     * @return the {@link EndpointType}, failure if the operation failed.
+     */
+    Result<EndpointType> parse(String endpointType);
+}


### PR DESCRIPTION
## WHAT

- Implement mqtt data endpoint type parser
- Register parser via extension

## WHY


## FURTHER NOTES

Closes #212
