### PR TITLE
feat: Implement mqtt data params oauth2 decorator for edrs

### DIFF
--- a/edc-extensions/mqtt/mqtt-data-params/build.gradle.kts
+++ b/edc-extensions/mqtt/mqtt-data-params/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 dependencies {
 
     api(libs.edc.spi.core)
+    api(libs.edc.spi.oauth2)
     api(project(":spi:mqtt:mqtt-data-params-spi"))
 
     testImplementation(libs.edc.junit)

--- a/edc-extensions/mqtt/mqtt-data-params/src/main/java/org/factoryx/edc/mqtt/data/params/MqttDataParamsExtension.java
+++ b/edc-extensions/mqtt/mqtt-data-params/src/main/java/org/factoryx/edc/mqtt/data/params/MqttDataParamsExtension.java
@@ -19,12 +19,15 @@
 
 package org.factoryx.edc.mqtt.data.params;
 
+import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.factoryx.edc.mqtt.data.params.basic.BasicAuthMqttParamsDecorator;
+import org.factoryx.edc.mqtt.data.params.oauth2.MqttOauth2CredentialsRequestFactory;
+import org.factoryx.edc.mqtt.data.params.oauth2.Oauth2MqttParamsDecorator;
 import org.factoryx.edc.mqtt.data.params.provider.MqttParamsProviderImpl;
 import org.factoryx.edc.mqtt.data.params.spi.MqttParamsProvider;
 
@@ -34,6 +37,9 @@ public class MqttDataParamsExtension implements ServiceExtension {
     @Inject
     private Vault vault;
 
+    @Inject
+    private Oauth2Client oauth2Client;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
 
@@ -41,6 +47,10 @@ public class MqttDataParamsExtension implements ServiceExtension {
 
         var basicAuthMqttParamsDecorator = new BasicAuthMqttParamsDecorator(vault);
         provider.registerDecorator(basicAuthMqttParamsDecorator);
+
+        var mqttOauth2CredentialsRequestFactory = new MqttOauth2CredentialsRequestFactory(vault);
+        var oauth2MqttParamsDecorator = new Oauth2MqttParamsDecorator(mqttOauth2CredentialsRequestFactory, oauth2Client);
+        provider.registerDecorator(oauth2MqttParamsDecorator);
 
         context.registerService(MqttParamsProvider.class, provider);
     }

--- a/edc-extensions/mqtt/mqtt-data-params/src/main/java/org/factoryx/edc/mqtt/data/params/oauth2/MqttOauth2CredentialsRequestFactory.java
+++ b/edc-extensions/mqtt/mqtt-data-params/src/main/java/org/factoryx/edc/mqtt/data/params/oauth2/MqttOauth2CredentialsRequestFactory.java
@@ -1,0 +1,58 @@
+/********************************************************************************
+ * Copyright (c) 2025 SAP SE
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.factoryx.edc.mqtt.data.params.oauth2;
+
+import org.eclipse.edc.iam.oauth2.spi.client.Oauth2CredentialsRequest;
+import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
+import org.factoryx.edc.mqtt.data.address.spi.MqttDataAddress;
+
+import java.util.Optional;
+
+public class MqttOauth2CredentialsRequestFactory {
+
+    public static final String GRANT_CLIENT_CREDENTIALS = "client_credentials";
+
+    private final Vault vault;
+
+    public MqttOauth2CredentialsRequestFactory(Vault vault) {
+        this.vault = vault;
+    }
+
+    public Result<Oauth2CredentialsRequest> create(MqttDataAddress dataAddress) {
+
+        return Optional.of(dataAddress)
+                .map(MqttDataAddress::getOauth2ClientSecretAlias)
+                .map(vault::resolveSecret)
+                .map(clientSecret -> buildRequest(clientSecret, dataAddress))
+                .map(Result::success)
+                .orElseGet(() -> Result.failure("Cannot resolve client secret from the vault: " + dataAddress.getOauth2ClientSecretAlias()));
+    }
+
+    private Oauth2CredentialsRequest buildRequest(String clientSecret, MqttDataAddress dataAddress) {
+        return SharedSecretOauth2CredentialsRequest.Builder.newInstance()
+                .url(dataAddress.getOauth2TokenUrl())
+                .grantType(GRANT_CLIENT_CREDENTIALS)
+                .clientId(dataAddress.getOauth2ClientId())
+                .clientSecret(clientSecret)
+                .build();
+    }
+}

--- a/edc-extensions/mqtt/mqtt-data-params/src/main/java/org/factoryx/edc/mqtt/data/params/oauth2/Oauth2MqttParamsDecorator.java
+++ b/edc-extensions/mqtt/mqtt-data-params/src/main/java/org/factoryx/edc/mqtt/data/params/oauth2/Oauth2MqttParamsDecorator.java
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2025 SAP SE
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.factoryx.edc.mqtt.data.params.oauth2;
+
+import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.factoryx.edc.mqtt.data.address.spi.MqttDataAddress;
+import org.factoryx.edc.mqtt.data.params.spi.MqttParams;
+import org.factoryx.edc.mqtt.data.params.spi.MqttParamsDecorator;
+
+public class Oauth2MqttParamsDecorator implements MqttParamsDecorator {
+
+    private final MqttOauth2CredentialsRequestFactory requestFactory;
+    private final Oauth2Client oauth2Client;
+
+    public Oauth2MqttParamsDecorator(MqttOauth2CredentialsRequestFactory requestFactory, Oauth2Client oauth2Client) {
+        this.requestFactory = requestFactory;
+        this.oauth2Client = oauth2Client;
+    }
+
+    @Override
+    public MqttParams.Builder decorate(MqttDataAddress address, MqttParams.Builder params) {
+
+        if (address.hasOauth2()) {
+            return requestFactory.create(address)
+                    .compose(oauth2Client::requestToken)
+                    .map(tokenRepresentation -> decorateParamFromToken(tokenRepresentation, params))
+                    .orElseThrow(failure -> new EdcException("Cannot Decorate Mqtt through OAuth2: " + failure.getFailureDetail()));
+        }
+        return params;
+    }
+
+    protected MqttParams.Builder decorateParamFromToken(TokenRepresentation tokenRepresentation, MqttParams.Builder params) {
+        return params.authorization(tokenRepresentation.getToken())
+                .expiresIn(Long.toString(tokenRepresentation.getExpiresIn()));
+    }
+}

--- a/edc-extensions/mqtt/mqtt-data-params/src/test/java/org/factoryx/edc/mqtt/data/params/MqttDataParamsExtensionTest.java
+++ b/edc-extensions/mqtt/mqtt-data-params/src/test/java/org/factoryx/edc/mqtt/data/params/MqttDataParamsExtensionTest.java
@@ -22,14 +22,19 @@ package org.factoryx.edc.mqtt.data.params;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.factoryx.edc.mqtt.data.params.basic.BasicAuthMqttParamsDecorator;
+import org.factoryx.edc.mqtt.data.params.oauth2.Oauth2MqttParamsDecorator;
+import org.factoryx.edc.mqtt.data.params.provider.MqttParamsProviderImpl;
 import org.factoryx.edc.mqtt.data.params.spi.MqttParamsProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedConstruction;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
 
 
@@ -46,8 +51,15 @@ class MqttDataParamsExtensionTest {
     @Test
     void testInitialize(ServiceExtensionContext context, MqttDataParamsExtension extension) {
 
-        extension.initialize(context);
+        try (MockedConstruction<MqttParamsProviderImpl> providerMock = mockConstruction(MqttParamsProviderImpl.class)) {
 
-        verify(context).registerService(eq(MqttParamsProvider.class), any(MqttParamsProvider.class));
+            extension.initialize(context);
+
+            MqttParamsProvider provider = providerMock.constructed().get(0);
+
+            verify(context).registerService(eq(MqttParamsProvider.class), any(MqttParamsProvider.class));
+            verify(provider).registerDecorator(any(BasicAuthMqttParamsDecorator.class));
+            verify(provider).registerDecorator(any(Oauth2MqttParamsDecorator.class));
+        }
     }
 }

--- a/edc-extensions/mqtt/mqtt-data-params/src/test/java/org/factoryx/edc/mqtt/data/params/oauth2/MqttOauth2CredentialsRequestFactoryTest.java
+++ b/edc-extensions/mqtt/mqtt-data-params/src/test/java/org/factoryx/edc/mqtt/data/params/oauth2/MqttOauth2CredentialsRequestFactoryTest.java
@@ -1,0 +1,91 @@
+/********************************************************************************
+ * Copyright (c) 2025 SAP SE
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.factoryx.edc.mqtt.data.params.oauth2;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.edc.spi.security.Vault;
+import org.factoryx.edc.mqtt.data.address.spi.MqttDataAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MqttOauth2CredentialsRequestFactoryTest {
+
+    private static final String OAUTH2_TOKEN_URL = "http://keycloak:8080/realms/demo/token";
+    private static final String OAUTH2_CLIENT_ID = "mqtt-client-id";
+    private static final String OAUTH2_CLIENT_SECRET = "mqtt-client-secret";
+    private static final String OAUTH2_CLIENT_SECRET_ALIAS = "mqtt-password-alias";
+
+    private static final String CLIENT_ID_KEY = "client_id";
+    private static final String CLIENT_SECRET_KEY = "client_secret";
+
+    private final Vault vault = mock();
+    private MqttOauth2CredentialsRequestFactory requestFactory;
+
+    @BeforeEach
+    void setup() {
+        requestFactory = new MqttOauth2CredentialsRequestFactory(vault);
+    }
+
+    @Test
+    void testOauthRequest() {
+
+        var dataAddress = MqttDataAddress.Builder.newInstance()
+                .oauth2TokenUrl(OAUTH2_TOKEN_URL)
+                .oauth2ClientId(OAUTH2_CLIENT_ID)
+                .oauth2ClientSecretAlias(OAUTH2_CLIENT_SECRET_ALIAS)
+                .build();
+
+        when(vault.resolveSecret(OAUTH2_CLIENT_SECRET_ALIAS)).thenReturn(OAUTH2_CLIENT_SECRET);
+
+        var result = requestFactory.create(dataAddress);
+
+        assertThat(result).isSucceeded().satisfies(request -> {
+            Assertions.assertThat(request.getGrantType()).isEqualTo(MqttOauth2CredentialsRequestFactory.GRANT_CLIENT_CREDENTIALS);
+            Assertions.assertThat(request.getUrl()).isEqualTo(OAUTH2_TOKEN_URL);
+            Assertions.assertThat(request.getParams()).containsEntry(CLIENT_ID_KEY, OAUTH2_CLIENT_ID).containsEntry(CLIENT_SECRET_KEY, OAUTH2_CLIENT_SECRET);
+        });
+        verify(vault).resolveSecret(OAUTH2_CLIENT_SECRET_ALIAS);
+    }
+
+    @Test
+    void testOauthRequestSecretMissingFromVault() {
+
+        var dataAddress = MqttDataAddress.Builder.newInstance()
+                .oauth2TokenUrl(OAUTH2_TOKEN_URL)
+                .oauth2ClientId(OAUTH2_CLIENT_ID)
+                .oauth2ClientSecretAlias(OAUTH2_CLIENT_SECRET_ALIAS)
+                .build();
+
+        when(vault.resolveSecret(OAUTH2_CLIENT_SECRET_ALIAS)).thenReturn(null);
+
+        var result = requestFactory.create(dataAddress);
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            Assertions.assertThat(failure.getMessages())
+                    .contains("Cannot resolve client secret from the vault: " + OAUTH2_CLIENT_SECRET_ALIAS);
+        });
+        verify(vault).resolveSecret(OAUTH2_CLIENT_SECRET_ALIAS);
+    }
+}

--- a/edc-extensions/mqtt/mqtt-data-params/src/test/java/org/factoryx/edc/mqtt/data/params/oauth2/Oauth2MqttParamsDecoratorTest.java
+++ b/edc-extensions/mqtt/mqtt-data-params/src/test/java/org/factoryx/edc/mqtt/data/params/oauth2/Oauth2MqttParamsDecoratorTest.java
@@ -1,0 +1,143 @@
+/********************************************************************************
+ * Copyright (c) 2025 SAP SE
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.factoryx.edc.mqtt.data.params.oauth2;
+
+import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
+import org.eclipse.edc.iam.oauth2.spi.client.Oauth2CredentialsRequest;
+import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.Result;
+import org.factoryx.edc.mqtt.data.address.spi.MqttDataAddress;
+import org.factoryx.edc.mqtt.data.params.spi.MqttConstants;
+import org.factoryx.edc.mqtt.data.params.spi.MqttParams;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.factoryx.edc.mqtt.data.params.oauth2.MqttOauth2CredentialsRequestFactory.GRANT_CLIENT_CREDENTIALS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class Oauth2MqttParamsDecoratorTest {
+
+    private static final String OAUTH2_TOKEN_URL = "http://keycloak:8080/realms/demo/token";
+    private static final String OAUTH2_CLIENT_ID = "mqtt-client-id";
+    private static final String OAUTH2_CLIENT_SECRET_ALIAS = "mqtt-password-alias";
+
+    private static final String AUTHORIZATION_TOKEN = "eyJraWQiOiJwdWJsaWMta2V5LWFsaWFzIiwiYWxnIjoiUlMyNTYifQ";
+
+    private final MqttOauth2CredentialsRequestFactory requestFactory = mock();
+    private final Oauth2Client oauth2Client = mock();
+    private Oauth2MqttParamsDecorator decorator;
+
+    @BeforeEach
+    void setup() {
+        decorator = new Oauth2MqttParamsDecorator(requestFactory, oauth2Client);
+    }
+
+    @Test
+    void testOauth2() {
+
+        var dataAddress = MqttDataAddress.Builder.newInstance()
+                .oauth2TokenUrl(OAUTH2_TOKEN_URL)
+                .oauth2ClientId(OAUTH2_CLIENT_ID)
+                .oauth2ClientSecretAlias(OAUTH2_CLIENT_SECRET_ALIAS)
+                .build();
+
+        Oauth2CredentialsRequest credentialsRequest = SharedSecretOauth2CredentialsRequest.Builder.newInstance()
+                .url(OAUTH2_TOKEN_URL)
+                .grantType(GRANT_CLIENT_CREDENTIALS)
+                .clientId(OAUTH2_CLIENT_ID)
+                .clientSecret(OAUTH2_CLIENT_SECRET_ALIAS)
+                .build();
+
+        when(requestFactory.create(dataAddress)).thenReturn(Result.success(credentialsRequest));
+        when(oauth2Client.requestToken(credentialsRequest)).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().token(AUTHORIZATION_TOKEN).expiresIn(300L).build()));
+
+        var params = decorator.decorate(dataAddress, MqttParams.Builder.newInstance()).build();
+
+        assertThat(params.getProperties())
+                .containsEntry(MqttConstants.AUTHORIZATION, AUTHORIZATION_TOKEN)
+                .containsEntry(MqttConstants.EXPIRES_IN, "300");
+    }
+
+    @Test
+    void testOauth2Missing() {
+
+        var dataAddress = MqttDataAddress.Builder.newInstance()
+                .oauth2TokenUrl(OAUTH2_TOKEN_URL)
+                .build();
+
+        var params = decorator.decorate(dataAddress, MqttParams.Builder.newInstance()).build();
+
+        assertThat(params.getProperties())
+                .doesNotContainKey(MqttConstants.AUTHORIZATION)
+                .doesNotContainKey(MqttConstants.EXPIRES_IN);
+
+        verify(requestFactory, never()).create(any());
+        verify(oauth2Client, never()).requestToken(any());
+    }
+
+    @Test
+    void testOauthCredentialRequestFailure() {
+
+        var dataAddress = MqttDataAddress.Builder.newInstance()
+                .oauth2TokenUrl(OAUTH2_TOKEN_URL)
+                .oauth2ClientId(OAUTH2_CLIENT_ID)
+                .oauth2ClientSecretAlias(OAUTH2_CLIENT_SECRET_ALIAS)
+                .build();
+
+        when(requestFactory.create(dataAddress)).thenReturn(Result.failure("Request Failure"));
+
+        assertThatThrownBy(() -> decorator.decorate(dataAddress, MqttParams.Builder.newInstance()))
+                .isInstanceOf(EdcException.class)
+                .hasMessageContaining("Cannot Decorate Mqtt through OAuth2: Request Failure");
+        verify(oauth2Client, never()).requestToken(any());
+    }
+
+    @Test
+    void testOauth2Oauth2TokenFailure() {
+
+        var dataAddress = MqttDataAddress.Builder.newInstance()
+                .oauth2TokenUrl(OAUTH2_TOKEN_URL)
+                .oauth2ClientId(OAUTH2_CLIENT_ID)
+                .oauth2ClientSecretAlias(OAUTH2_CLIENT_SECRET_ALIAS)
+                .build();
+
+        Oauth2CredentialsRequest credentialsRequest = SharedSecretOauth2CredentialsRequest.Builder.newInstance()
+                .url(OAUTH2_TOKEN_URL)
+                .grantType(GRANT_CLIENT_CREDENTIALS)
+                .clientId(OAUTH2_CLIENT_ID)
+                .clientSecret(OAUTH2_CLIENT_SECRET_ALIAS)
+                .build();
+
+        when(requestFactory.create(dataAddress)).thenReturn(Result.success(credentialsRequest));
+        when(oauth2Client.requestToken(credentialsRequest)).thenReturn(Result.failure("Oauth2 Token Request Failure"));
+
+        assertThatThrownBy(() -> decorator.decorate(dataAddress, MqttParams.Builder.newInstance()))
+                .isInstanceOf(EdcException.class)
+                .hasMessageContaining("Cannot Decorate Mqtt through OAuth2: Oauth2 Token Request Failure");
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ edc-spi-vc = { module = "org.eclipse.edc:verifiable-credentials-spi", version.re
 edc-spi-web = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
 edc-spi-http = { module = "org.eclipse.edc:http-spi", version.ref = "edc" }
 edc-spi-validator = { module = "org.eclipse.edc:validator-spi", version.ref = "edc" }
+edc-spi-oauth2 = { module = "org.eclipse.edc:oauth2-spi", version.ref = "edc" }
 #edc-boot = { module = "org.eclipse.edc:boot", version.ref = "edc" }
 edc-build-plugin = { module = "org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin", version.ref = "edc" }
 #edc-core-controlplane = { module = "org.eclipse.edc:control-plane-core", version.ref = "edc" }


### PR DESCRIPTION
## WHAT

- Implement mqtt data params oauth2 decorator for edrs

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #227 