### PR TITLE
fix: Fix Initiate EDR / Transfer API for Mqtt Data Asset

### DIFF
--- a/edc-extensions/mqtt/mqtt-data-flow/build.gradle.kts
+++ b/edc-extensions/mqtt/mqtt-data-flow/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     api(libs.edc.spi.dataplane.selector)
     api(libs.edc.spi.web)
     implementation(libs.edc.spi.transfer)
-    implementation(project(":spi:mqtt:mqtt-data-address-spi"))
+    api(project(":spi:mqtt:mqtt-data-address-spi"))
     implementation(project(":spi:mqtt:mqtt-data-endpoint-spi"))
     implementation(project(":spi:mqtt:mqtt-data-params-spi"))
 

--- a/edc-extensions/mqtt/mqtt-data-flow/src/test/java/org/factoryx/edc/mqtt/data/flow/controller/MqttDataFlowControllerTest.java
+++ b/edc-extensions/mqtt/mqtt-data-flow/src/test/java/org/factoryx/edc/mqtt/data/flow/controller/MqttDataFlowControllerTest.java
@@ -50,6 +50,8 @@ import java.net.URI;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.Type.PROVIDER;
+import static org.eclipse.edc.dataaddress.httpdata.spi.HttpDataAddressSchema.HTTP_DATA_TYPE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.factoryx.edc.mqtt.data.address.spi.MqttDataAddressSchema.MQTT_DATA_ADDRESS_TYPE;
@@ -83,6 +85,7 @@ class MqttDataFlowControllerTest {
 
         var transferProcess = TransferProcess.Builder.newInstance()
                 .transferType(MQTT_DATA_PULL)
+                .type(PROVIDER)
                 .contentDataAddress(DataAddress.Builder.newInstance().type(MQTT_DATA_ADDRESS_TYPE).build())
                 .build();
 
@@ -95,6 +98,22 @@ class MqttDataFlowControllerTest {
 
     @Test
     void testCanHandleTransferParseFailure() {
+
+        var transferProcess = TransferProcess.Builder.newInstance()
+                .transferType(MQTT_DATA_PULL)
+                .type(PROVIDER)
+                .contentDataAddress(DataAddress.Builder.newInstance().type(MQTT_DATA_ADDRESS_TYPE).build())
+                .build();
+
+        when(transferTypeParser.parse(MQTT_DATA_PULL)).thenReturn(Result.failure("Transfer Type Parse Failed"));
+
+        var result = flowController.canHandle(transferProcess);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void testCanHandleTransferParseFailureConsumer() {
 
         var transferProcess = TransferProcess.Builder.newInstance()
                 .transferType(MQTT_DATA_PULL)
@@ -113,7 +132,8 @@ class MqttDataFlowControllerTest {
 
         var transferProcess = TransferProcess.Builder.newInstance()
                 .transferType("Kafka-PULL")
-                .contentDataAddress(DataAddress.Builder.newInstance().type(MQTT_DATA_ADDRESS_TYPE).build())
+                .type(PROVIDER)
+                .contentDataAddress(DataAddress.Builder.newInstance().type(HTTP_DATA_TYPE).build())
                 .build();
 
         when(transferTypeParser.parse("Kafka-PULL")).thenReturn(Result.success(new TransferType("Kafka", FlowType.PULL)));

--- a/edc-extensions/mqtt/mqtt-data-params/src/test/java/org/factoryx/edc/mqtt/data/params/base/BaseCommonMqttParamsDecoratorTest.java
+++ b/edc-extensions/mqtt/mqtt-data-params/src/test/java/org/factoryx/edc/mqtt/data/params/base/BaseCommonMqttParamsDecoratorTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.factoryx.edc.mqtt.data.address.spi.MqttDataAddressSchema.BASE_URL;
-import static org.factoryx.edc.mqtt.data.address.spi.MqttDataAddressSchema.MQTT_ENDPOINT_TYPE;
+import static org.factoryx.edc.mqtt.data.params.spi.MqttConstants.BASE_URL;
+import static org.factoryx.edc.mqtt.data.params.spi.MqttConstants.MQTT_ENDPOINT_TYPE;
 
 class BaseCommonMqttParamsDecoratorTest {
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ edc-spi-web = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
 edc-spi-http = { module = "org.eclipse.edc:http-spi", version.ref = "edc" }
 edc-spi-validator = { module = "org.eclipse.edc:validator-spi", version.ref = "edc" }
 edc-spi-oauth2 = { module = "org.eclipse.edc:oauth2-spi", version.ref = "edc" }
+edc-spi-data-address-http = { module = "org.eclipse.edc:data-address-http-data-spi", version.ref = "edc" }
 #edc-boot = { module = "org.eclipse.edc:boot", version.ref = "edc" }
 edc-build-plugin = { module = "org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin", version.ref = "edc" }
 #edc-core-controlplane = { module = "org.eclipse.edc:control-plane-core", version.ref = "edc" }

--- a/spi/mqtt/mqtt-data-address-spi/build.gradle.kts
+++ b/spi/mqtt/mqtt-data-address-spi/build.gradle.kts
@@ -24,5 +24,6 @@ plugins {
 dependencies {
 
     api(libs.edc.spi.core)
+    api(libs.edc.spi.data.address.http)
     api(project(":spi:core-spi"))
 }

--- a/spi/mqtt/mqtt-data-address-spi/src/main/java/org/factoryx/edc/mqtt/data/address/spi/MqttDataAddressSchema.java
+++ b/spi/mqtt/mqtt-data-address-spi/src/main/java/org/factoryx/edc/mqtt/data/address/spi/MqttDataAddressSchema.java
@@ -22,7 +22,7 @@ package org.factoryx.edc.mqtt.data.address.spi;
 
 import org.eclipse.edc.spi.types.domain.transfer.FlowType;
 
-import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.dataaddress.httpdata.spi.HttpDataAddressSchema.HTTP_DATA_TYPE;
 
 public interface MqttDataAddressSchema {
 
@@ -31,8 +31,9 @@ public interface MqttDataAddressSchema {
      */
     String MQTT_DATA_ADDRESS_TYPE = "Mqtt";
     String MQTT_DATA_PULL = "%s-%s".formatted(MQTT_DATA_ADDRESS_TYPE, FlowType.PULL);
+    String HTTP_DATA_PULL = "%s-%s".formatted(HTTP_DATA_TYPE, FlowType.PULL);
 
-    String BASE_URL = EDC_NAMESPACE + "baseUrl";
+    String BASE_URL = "baseUrl";
     String MQTT_ENDPOINT_TYPE = "mqttEndpointType";
     String OAUTH2_TOKEN_URL = "oauth2:tokenUrl";
     String OAUTH2_CLIENT_ID = "oauth2:clientId";

--- a/spi/mqtt/mqtt-data-params-spi/src/main/java/org/factoryx/edc/mqtt/data/params/spi/MqttConstants.java
+++ b/spi/mqtt/mqtt-data-params-spi/src/main/java/org/factoryx/edc/mqtt/data/params/spi/MqttConstants.java
@@ -24,6 +24,9 @@ public interface MqttConstants {
     String DSP_MQTT_PREFIX = "dsp-mqtt";
     String DSP_MQTT_NS = "https://w3id.org/dspace/2025/1/mqtt-pull/";
 
+    String MQTT_ENDPOINT_TYPE = DSP_MQTT_NS + "mqttEndpointType";
+    String BASE_URL = DSP_MQTT_NS + "baseUrl";
+
     String USERNAME = DSP_MQTT_NS + "username";
     String PASSWORD = DSP_MQTT_NS + "password";
 

--- a/spi/mqtt/mqtt-data-params-spi/src/main/java/org/factoryx/edc/mqtt/data/params/spi/MqttParams.java
+++ b/spi/mqtt/mqtt-data-params-spi/src/main/java/org/factoryx/edc/mqtt/data/params/spi/MqttParams.java
@@ -23,10 +23,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.factoryx.edc.mqtt.data.address.spi.MqttDataAddressSchema.BASE_URL;
-import static org.factoryx.edc.mqtt.data.address.spi.MqttDataAddressSchema.MQTT_ENDPOINT_TYPE;
 import static org.factoryx.edc.mqtt.data.params.spi.MqttConstants.AUTHORIZATION;
+import static org.factoryx.edc.mqtt.data.params.spi.MqttConstants.BASE_URL;
 import static org.factoryx.edc.mqtt.data.params.spi.MqttConstants.EXPIRES_IN;
+import static org.factoryx.edc.mqtt.data.params.spi.MqttConstants.MQTT_ENDPOINT_TYPE;
 import static org.factoryx.edc.mqtt.data.params.spi.MqttConstants.PASSWORD;
 import static org.factoryx.edc.mqtt.data.params.spi.MqttConstants.REFRESH_AUDIENCE;
 import static org.factoryx.edc.mqtt.data.params.spi.MqttConstants.REFRESH_TOKEN;


### PR DESCRIPTION
## WHAT

- Use `HttpData-PULL` as transfer type in data flow controller.
- Initiate data flow with `HttpData-PULL` data address type.

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
