### PR TITLE
fix: Prevent Draft Release to add unintended files

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -52,15 +52,3 @@ jobs:
 
       - name: Run Backend EndToEnd Tests
         run: ./gradlew test -DincludeTags="EndToEndTest"
-
-      - name: Generate Dependency Report
-        working-directory: ./
-        run: ./gradlew dependencies > dependency-report.txt
-
-      # Upload Dependency Report
-      - name: Upload Dependency Report
-        uses: actions/upload-artifact@v4
-        with:
-          name: dependency-report
-          path: ./dependency-report.txt
-

--- a/.gitignore
+++ b/.gitignore
@@ -109,5 +109,9 @@ buildNumber.properties
 ### Helm
 **/*.lock
 **/*.tgz
+semicolon_delimited_script
 
-edc-tests/miw-tests/src/test/resources/docker-environment/postgres_data/
+# temp files needed for generate-and-check-dependencies action
+dash.jar
+dependency-list
+DEPENDENCIES

--- a/semicolon_delimited_script
+++ b/semicolon_delimited_script
@@ -1,2 +1,0 @@
-helm-docs --log-level debug
-


### PR DESCRIPTION
## WHAT

- Add unintended files to `.gitignore` to prevent accidental checkins.
- Remove dependecny-report steps from `backend-ci.yml` as it doesn't add any value
- Delete `semicolon_delimited_script` generated from helm-docs workflow and add it to `.gitignore`


## WHY



## FURTHER NOTES

Closes #188 
