### PR TITLE
fix: Increment minor version while release

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -48,7 +48,7 @@ jobs:
             echo "$VERSION is not a final release version (contains \"$SNAPSHOT\"), will not increase patch"
           fi
           
-          VERSION="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+$INC))-SNAPSHOT"
+          VERSION="$RELEASE_VERSION_MAJOR.$((RELEASE_VERSION_MINOR+$INC)).0-SNAPSHOT"
           SNAPSHOT_VERSION=$VERSION
           
           # Persist the "version" in the gradle.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.factoryx.edc
-version=0.1.4-SNAPSHOT
+version=0.1.5-SNAPSHOT
 # configure the build:
 fxScmConnection=scm:git:git@github.com:factory-x-contributions/factoryx-edc.git
 fxWebsiteUrl=https://github.com/factory-x-contributions/factoryx-edc.git


### PR DESCRIPTION
## WHAT

- Increment minor version during bump-version workflow.
- Update snapshot version `0.1.5-SNAPSHOT` since, `0.1.4` is already released.

> Next normal release version order will be `0.2.0`, `0.3.0`, `0.4.0` etc.
> And now, we can do bug fixes on old versions with releases `0.2.1`, `0.2.2`, `0.3.1`, `0.4.1`, etc.

## WHY


## FURTHER NOTES
Workflow run: https://github.com/pratapipatelbcone/factoryx-edc/actions/runs/19074791886

Closes #286 
