### PR TITLE
fix: Bump Version Workflow checkout with bot PAT

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: '${{ secrets.GH_PAT }}'
       - name: Set new snapshot version
         shell: bash
         run: |


### PR DESCRIPTION
## WHAT
- Bump Version Workflow -  checkout step with factoryx-bot PAT, to allow commit on main branch

## WHY

## FURTHER NOTES

Closes #271 
