### PR TITLE
fix: Allow fixed set of credential for extracting scope

### DIFF
--- a/edc-extensions/dcp/fx-dcp/src/main/java/org/factoryx/edc/iam/iatp/IatpDefaultScopeExtension.java
+++ b/edc-extensions/dcp/fx-dcp/src/main/java/org/factoryx/edc/iam/iatp/IatpDefaultScopeExtension.java
@@ -55,9 +55,6 @@ public class IatpDefaultScopeExtension implements ServiceExtension {
 
     @Setting(context = TX_IATP_DEFAULT_SCOPE_PREFIX_CONFIG_ALIAS, value = "The alias of the scope e.g. read", required = true)
     public static final String OPERATION = "operation";
-    public static final String CATALOG_REQUEST_SCOPE = "request.catalog";
-    public static final String NEGOTIATION_REQUEST_SCOPE = "request.contract.negotiation";
-    public static final String TRANSFER_PROCESS_REQUEST_SCOPE = "request.transfer.process";
     static final String NAME = "Tractusx default scope extension";
     @Inject
     private PolicyEngine policyEngine;


### PR DESCRIPTION
## WHAT
- Allow fixed set of credential for extracting scope

## WHY
- TO avoid any random credentials to be requested from Wallet (e.g. DIV)

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
