### PR TITLE
feat: Enable postgres persistence in helm chart

### DIFF
--- a/charts/factoryx-connector/values.yaml
+++ b/charts/factoryx-connector/values.yaml
@@ -628,10 +628,12 @@ postgresql:
   jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"
   primary:
     persistence:
-      enabled: false
+      enabled: true
+      size: 4Gi
   readReplicas:
     persistence:
-      enabled: false
+      enabled: true
+      size: 4Gi
   auth:
     database: "edc"
     username: "user"


### PR DESCRIPTION
## WHAT
- Enable postgres persistence in helm chart

## WHY


## FURTHER NOTES


Closes #338 
