### PR TITLE
feat: Upgrade to Java 25 LTS

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -19,15 +19,15 @@
 
 
 ---
-name: "Setup JDK 17"
-description: "Setup JDK 17"
+name: "Setup JDK 21"
+description: "Setup JDK 21"
 runs:
   using: "composite"
   steps:
-    - name: Setup JDK 17
-      uses: actions/setup-java@v4.1.0
+    - name: Setup JDK 21
+      uses: actions/setup-java@v5.1.0
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v5

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
@@ -11,7 +11,7 @@ Factory-X product(s) installed within the image:
 - Project license: [Apache License, Version 2.0](https://github.com/factory-x-contributions/factoryx-edc/blob/main/LICENSE)
 
 ## Used base image
-- [eclipse-temurin:23_37-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:25.0.1_8-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: <https://hub.docker.com/_/eclipse-temurin>
 - Eclipse Temurin Project: <https://projects.eclipse.org/projects/adoptium.temurin>
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-runtime-memory/notice.md
+++ b/edc-controlplane/edc-runtime-memory/notice.md
@@ -16,7 +16,7 @@ Factory-X product(s) installed within the image:
 - Project license: [Apache License, Version 2.0](https://github.com/factory-x-contributions/factoryx-edc/blob/main/LICENSE)
 
 ## Used base image
-- [eclipse-temurin:23_37-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:25.0.1_8-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: <https://hub.docker.com/_/eclipse-temurin>
 - Eclipse Temurin Project: <https://projects.eclipse.org/projects/adoptium.temurin>
 - Additional information about the Eclipse Temurin

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
@@ -11,7 +11,7 @@ Factory-X product(s) installed within the image:
 - Project license: [Apache License, Version 2.0](https://github.com/factory-x-contributions/factoryx-edc/blob/main/LICENSE)
 
 ## Used base image
-- [eclipse-temurin:23_37-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:25.0.1_8-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: <https://hub.docker.com/_/eclipse-temurin>
 - Eclipse Temurin Project: <https://projects.eclipse.org/projects/adoptium.temurin>
 - Additional information about the Eclipse Temurin

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -19,7 +19,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #################################################################################
 
-FROM eclipse-temurin:24.0.2_12-jre-alpine
+FROM eclipse-temurin:25.0.1_8-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 ARG ADDITIONAL_FILES


### PR DESCRIPTION
## WHAT

- Upgrade Docker Images to Java 25 LTS
- Upgrade CI to use Java 21 as base code support.

## WHY
- Non LTS to LTS

## FURTHER NOTES

Closes #330 