### PR TITLE
feat: Use github.repository_owner in place of hard coded name

### DIFF
--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/trigger-docker-publish.yaml
     secrets: inherit
     with:
-      namespace: "ghcr.io/factory-x-contributions"
+      namespace: "ghcr.io/${{ github.repository_owner }}"
       docker_tag: ${{ needs.determine-version.outputs.VERSION }}
 
   publish-maven-artifacts:


### PR DESCRIPTION
## WHAT
- Use `github.repository_owner` in place of hard coded name `factory-x-contributions`

## WHY


## FURTHER NOTES

Closes #303 
