### PR TITLE
fix: equip cla with bot account

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -39,10 +39,10 @@ jobs:
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret
           # This token is required only if you have configured to store the signatures in a remote repository/organization
-          # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PAT }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://developercertificate.org/' # e.g. a CLA or a DCO document


### PR DESCRIPTION
## WHAT

allow cla action to bypass main push branch protection by equiping it with a pat bound to our bot account 

## WHY

failed workflow run
