### PR TITLE
fix: exclude cx-policy-legacy

### DIFF
--- a/edc-controlplane/edc-controlplane-base/build.gradle.kts
+++ b/edc-controlplane/edc-controlplane-base/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
         exclude( "org.eclipse.tractusx.edc", "cx-dataspace-protocol")
         exclude( "org.eclipse.tractusx.edc", "dataspace-protocol-core")
         exclude( "org.eclipse.tractusx.edc", "json-ld-cx")
+        exclude("org.eclipse.tractusx.edc", "cx-policy-legacy")
     }
 
     // fx-edc extensions


### PR DESCRIPTION
## WHAT

excludes a Catena-X specific extension missed in previous exclusions

## FURTHER NOTES

Closes #369