### PR TITLE
feat: remove 0.8

### DIFF
--- a/edc-extensions/fx-legacy-dataspace-protocol/README.md
+++ b/edc-extensions/fx-legacy-dataspace-protocol/README.md
@@ -1,0 +1,4 @@
+### fx-legacy-dataspace-protocol
+
+This extension is marked legacy because it will eventually be replaced by the midstream's [dataspace-protocol-core](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/edc-extensions/dataspace-protocol/dataspace-protocol-core/src/main/java/org/eclipse/tractusx/edc/protocol/core/CoreDataspaceProtocolExtension.java)
+extension when it's released.

--- a/edc-extensions/fx-legacy-dataspace-protocol/src/main/java/org/factoryx/edc/protocol/protocol/DataspaceProtocolExtension.java
+++ b/edc-extensions/fx-legacy-dataspace-protocol/src/main/java/org/factoryx/edc/protocol/protocol/DataspaceProtocolExtension.java
@@ -28,8 +28,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
-import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
-import static org.eclipse.edc.protocol.dsp.spi.type.Dsp08Constants.V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_PATH;
@@ -44,7 +42,6 @@ public class DataspaceProtocolExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        contextRegistry.register(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP, V_08, () -> dspWebhookAddress.get(), new DefaultDcpParticipantIdExtractionFunction()));
         contextRegistry.register(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP_V_2025_1, V_2025_1, () -> dspWebhookAddress.get() + V_2025_1_PATH, new DefaultDcpParticipantIdExtractionFunction()));
     }
 }

--- a/edc-extensions/fx-legacy-dataspace-protocol/src/test/java/org/factoryx/edc/protocol/protocol/DataspaceProtocolExtensionTest.java
+++ b/edc-extensions/fx-legacy-dataspace-protocol/src/test/java/org/factoryx/edc/protocol/protocol/DataspaceProtocolExtensionTest.java
@@ -30,8 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
-import static org.eclipse.edc.protocol.dsp.spi.type.Dsp08Constants.V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_PATH;
@@ -60,11 +58,6 @@ class DataspaceProtocolExtensionTest {
     void initialize_shouldRegisterProfileContexts(ObjectFactory factory, ServiceExtensionContext context) {
         factory.constructInstance(DataspaceProtocolExtension.class).initialize(context);
 
-        verify(dataspaceProfileContextRegistry).register(argThat(
-                dataspaceProfileContext -> dataspaceProfileContext.name().equals(DATASPACE_PROTOCOL_HTTP) &&
-                        dataspaceProfileContext.protocolVersion().equals(V_08) &&
-                        dataspaceProfileContext.webhook().url().equals(webhook) &&
-                        dataspaceProfileContext.idExtractionFunction() instanceof DefaultDcpParticipantIdExtractionFunction));
         verify(dataspaceProfileContextRegistry).register(argThat(
                 dataspaceProfileContext -> dataspaceProfileContext.name().equals(DATASPACE_PROTOCOL_HTTP_V_2025_1) &&
                         dataspaceProfileContext.protocolVersion().equals(V_2025_1) &&


### PR DESCRIPTION
## WHAT

Removes support for DSP 0.8

## WHY

legacy, customers are migrated to 2025-1

## FURTHER NOTES

Closes #318