### PR TITLE
feat: add credential-gated Bruno policy examples

### DIFF
--- a/docs/usage/management-api-walkthrough/02_policies.md
+++ b/docs/usage/management-api-walkthrough/02_policies.md
@@ -158,7 +158,7 @@ A policy holding this constraint can be created like this:
     "permission": {
       "action": "use",
       "constraint": {
-        "leftOperand": "Membership",
+        "leftOperand": "https://w3id.org/factoryx/policy/v1.0/FxMembership",
         "operator": "eq",
         "rightOperand": "active"
       }

--- a/docs/usage/management-api-walkthrough/README.md
+++ b/docs/usage/management-api-walkthrough/README.md
@@ -1,0 +1,15 @@
+# EDC Management API Walkthrough
+
+This folder has some quick guides for using the EDC management API.
+
+1. [Creating an Asset](01_assets.md)
+2. [Policies](02_policies.md)
+3. [Contract Definitions](03_contractdefinitions.md)
+4. [Catalog](04_catalog.md)
+5. [Contract Negotiations](05_contractnegotiations.md)
+6. [Transfer Processes](06_transferprocesses.md)
+7. [Endpoint Data References (EDRs)](07_edrs.md)
+8. [Contract Agreements](08_contractagreements.md)
+9. [Response Channels](09_responsechannels.md)
+
+Check each file for examples and details.

--- a/edc-extensions/dcp/fx-dcp/src/main/java/org/factoryx/edc/iam/iatp/scope/CredentialScopeExtractor.java
+++ b/edc-extensions/dcp/fx-dcp/src/main/java/org/factoryx/edc/iam/iatp/scope/CredentialScopeExtractor.java
@@ -45,6 +45,8 @@ import static org.factoryx.edc.iam.iatp.constant.FxDcpConstants.CREDENTIAL_TYPE_
  * The left operand should be bound to the namespace {@link CoreConstants#FX_CREDENTIAL_NS}
  */
 public class CredentialScopeExtractor implements ScopeExtractor {
+    private static final String MEMBERSHIP_LITERAL = "Membership";
+    private static final String FX_MEMBERSHIP_LITERAL = "FxMembership";
     /**
      * Prefix to extract certification type
      */
@@ -117,6 +119,9 @@ public class CredentialScopeExtractor implements ScopeExtractor {
     private String extractCredentialType(String leftOperand, Object rightValue) {
         var ix = leftOperand.indexOf(".");
         leftOperand = ix > 0 ? leftOperand.substring(0, ix) : leftOperand;
+        if (FX_MEMBERSHIP_LITERAL.equals(leftOperand) || MEMBERSHIP_LITERAL.equals(leftOperand)) {
+            return MEMBERSHIP_LITERAL;
+        }
         return leftOperand;
     }
 

--- a/edc-extensions/dcp/fx-dcp/src/test/java/org/factoryx/edc/iam/iatp/scope/CredentialScopeExtractorTest.java
+++ b/edc-extensions/dcp/fx-dcp/src/test/java/org/factoryx/edc/iam/iatp/scope/CredentialScopeExtractorTest.java
@@ -121,7 +121,8 @@ public class CredentialScopeExtractorTest {
             var offer = ContractOffer.Builder.newInstance().id("id").assetId("assetId").policy(Policy.Builder.newInstance().build()).build();
             return Stream.of(
                     Arguments.of(ContractRequestMessage.Builder.newInstance().contractOffer(offer).callbackAddress("cb").build(), CoreConstants.FX_POLICY_NS + "Membership",  CREDENTIAL_TYPE_NAMESPACE + ":MembershipCredential:read"),
-                    Arguments.of(TransferRequestMessage.Builder.newInstance().callbackAddress("cb").build(), CoreConstants.FX_POLICY_NS + "FxMembership",  CREDENTIAL_TYPE_NAMESPACE + ":FxMembershipCredential:read"),
+                    Arguments.of(ContractRequestMessage.Builder.newInstance().contractOffer(offer).callbackAddress("cb").build(), CoreConstants.FX_POLICY_NS + "FxMembership",  CREDENTIAL_TYPE_NAMESPACE + ":MembershipCredential:read"),
+                    Arguments.of(TransferRequestMessage.Builder.newInstance().callbackAddress("cb").build(), CoreConstants.FX_POLICY_NS + "FxMembership",  CREDENTIAL_TYPE_NAMESPACE + ":MembershipCredential:read"),
                     Arguments.of(CatalogRequestMessage.Builder.newInstance().build(), CoreConstants.FX_POLICY_NS + CERTIFICATION_TYPE_PREFIX + ".pfc",  CREDENTIAL_TYPE_NAMESPACE + ":CertificationCredential:read")
             );
         }

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/folder.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/folder.bru
@@ -1,0 +1,34 @@
+meta {
+  name: credential-gated transactions
+  seq: 4
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  # Credential-gated Example
+  
+  It demonstrates how Factory-X EDC policies can gate access to assets based on verifiable credentials held by the consumer.
+  
+  ## Overview
+  
+  The provider creates two assets, each protected by a different credential-based policy:
+  - membership-gated-asset: Requires a valid `MembershipCredential` (the consumer has this)
+  - certification-gated-asset: Requires an `ISO9001` `CertificationCredential` which the consumer won't have
+  
+  ## Test Scenarios
+  
+  1. Without credential – The consumer requests the catalog for the certification-gated asset. Because the consumer lacks an ISO9001 CertificationCredential, the asset is filtered from the catalog response.
+  2. With credential – The consumer requests the catalog for the membership-gated asset. Because the consumer holds a valid MembershipCredential, the asset is visible. The consumer then completes the full negotiation and data transfer.
+  
+  ## Prerequisites
+  
+  - Run all steps in the `identities` folder first (issuer setup, consumer/provider identity creation, credential issuance)
+  - Run this example before the default `provider`/`consumer` transaction flow, or in a fresh environment. The default flow creates a contract definition with an empty asset selector (matching all assets), which would bypass the credential-gated access policies.
+  
+  ## No Third EDC Required
+  
+  Both the positive and negative cases are demonstrated using the existing consumer and provider. The consumer holds a MembershipCredential but lacks a CertificationCredential. This asymmetry is used to show both outcomes without requiring a third participant.
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateCertificationContractDef.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateCertificationContractDef.bru
@@ -1,7 +1,7 @@
 meta {
-  name: CreateContractDefinition
+  name: CreateCertificationContractDef
   type: http
-  seq: 3
+  seq: 6
 }
 
 post {
@@ -19,14 +19,14 @@ body:json {
     "@context": {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
     },
-    "@id": "1",
-    "accessPolicyId": "aPolicy",
-    "contractPolicyId": "aPolicy",
+    "@id": "certification-contract-def",
+    "accessPolicyId": "certificationPolicy",
+    "contractPolicyId": "certificationPolicy",
     "assetsSelector": {
       "@type": "CriterionDto",
       "operandLeft": "https://w3id.org/edc/v0.0.1/ns/id",
       "operator": "=",
-      "operandRight": "assetId"
+      "operandRight": "certification-gated-asset"
     }
   }
 }

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateCertificationGatedAsset.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateCertificationGatedAsset.bru
@@ -1,0 +1,40 @@
+meta {
+  name: CreateCertificationGatedAsset
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{PROVIDER_MANAGEMENT}}/v3/assets
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{PROVIDER_MANAGEMENT_API_KEY}}
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@id": "certification-gated-asset",
+    "properties": {
+      "name": "Certification-gated product data",
+      "description": "This asset is only accessible to consumers with an ISO9001 CertificationCredential.",
+      "contenttype": "application/json"
+    },
+    "dataAddress": {
+      "type": "HttpData",
+      "name": "Certification-gated test data",
+      "baseUrl": "https://jsonplaceholder.typicode.com/comments",
+      "proxyPath": "true"
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateCertificationPolicy.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateCertificationPolicy.bru
@@ -1,0 +1,47 @@
+meta {
+  name: CreateCertificationPolicy
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{PROVIDER_MANAGEMENT}}/v3/policydefinitions
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{PROVIDER_MANAGEMENT_API_KEY}}
+}
+
+body:json {
+  {
+    "@context": [
+      "https://w3id.org/factoryx/policy/v1.0/context.jsonld",
+      "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+      {
+        "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      }
+    ],
+    "@type": "PolicyDefinition",
+    "@id": "certificationPolicy",
+    "policy": {
+      "@type": "Set",
+      "permission": {
+        "action": "use",
+        "constraint": {
+          "leftOperand": "CertificationType",
+          "operator": "eq",
+          "rightOperand": "ISO9001"
+        }
+      },
+      "prohibition": [],
+      "obligation": []
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateMembershipContractDef.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateMembershipContractDef.bru
@@ -1,7 +1,7 @@
 meta {
-  name: CreateContractDefinition
+  name: CreateMembershipContractDef
   type: http
-  seq: 3
+  seq: 5
 }
 
 post {
@@ -19,14 +19,14 @@ body:json {
     "@context": {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
     },
-    "@id": "1",
-    "accessPolicyId": "aPolicy",
-    "contractPolicyId": "aPolicy",
+    "@id": "membership-contract-def",
+    "accessPolicyId": "membershipPolicy",
+    "contractPolicyId": "membershipPolicy",
     "assetsSelector": {
       "@type": "CriterionDto",
       "operandLeft": "https://w3id.org/edc/v0.0.1/ns/id",
       "operator": "=",
-      "operandRight": "assetId"
+      "operandRight": "membership-gated-asset"
     }
   }
 }

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateMembershipGatedAsset.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateMembershipGatedAsset.bru
@@ -1,0 +1,40 @@
+meta {
+  name: CreateMembershipGatedAsset
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{PROVIDER_MANAGEMENT}}/v3/assets
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{PROVIDER_MANAGEMENT_API_KEY}}
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@id": "membership-gated-asset",
+    "properties": {
+      "name": "Membership-gated product data",
+      "description": "This asset is only accessible to consumers with a valid MembershipCredential.",
+      "contenttype": "application/json"
+    },
+    "dataAddress": {
+      "type": "HttpData",
+      "name": "Membership-gated test data",
+      "baseUrl": "https://jsonplaceholder.typicode.com/posts",
+      "proxyPath": "true"
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateMembershipPolicy.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/CreateMembershipPolicy.bru
@@ -1,0 +1,47 @@
+meta {
+  name: CreateMembershipPolicy
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{PROVIDER_MANAGEMENT}}/v3/policydefinitions
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{PROVIDER_MANAGEMENT_API_KEY}}
+}
+
+body:json {
+  {
+    "@context": [
+      "https://w3id.org/factoryx/policy/v1.0/context.jsonld",
+      "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+      {
+        "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      }
+    ],
+    "@type": "PolicyDefinition",
+    "@id": "membershipPolicy",
+    "policy": {
+      "@type": "Set",
+      "permission": {
+        "action": "use",
+        "constraint": {
+          "leftOperand": "https://w3id.org/factoryx/policy/v1.0/FxMembership",
+          "operator": "eq",
+          "rightOperand": "active"
+        }
+      },
+      "prohibition": [],
+      "obligation": []
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/folder.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/provider setup/folder.bru
@@ -1,0 +1,17 @@
+meta {
+  name: provider setup
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  The provider creates two data assets, each protected by a credential-based policy:
+
+  1. A membership-gated asset bound to a policy requiring `Membership = active`. Any Factory-X dataspace member with a valid MembershipCredential can access this asset.
+  2. A certification-gated asset bound to a policy requiring `CertificationType = ISO9001`. Only consumers holding an ISO9001 CertificationCredential can access this asset.
+
+  Each asset is linked to its policy via a dedicated contract definition with a specific asset selector.
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/CheckNegotiationResult.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/CheckNegotiationResult.bru
@@ -1,0 +1,31 @@
+meta {
+  name: CheckNegotiationResult
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{CONSUMER_MANAGEMENT}}/v3/contractnegotiations/{{protectedNegotiationId}}
+  body: none
+  auth: inherit
+}
+
+headers {
+  Accept: application/json
+  x-api-key: {{CONSUMER_MANAGEMENT_API_KEY}}
+}
+
+script:post-response {
+  const body = res.getBody();
+  const state = body['state'];
+  const contractId = body['contractAgreementId'];
+  
+  if (contractId) {
+    bru.setEnvVar("protectedContractId", contractId);
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/Get EDR.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/Get EDR.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Get EDR
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{CONSUMER_MANAGEMENT}}/v3/edrs/{{protectedTransferId}}/dataaddress
+  body: none
+  auth: inherit
+}
+
+headers {
+  Accept: application/json
+  x-api-key: {{CONSUMER_MANAGEMENT_API_KEY}}
+}
+
+script:post-response {
+  const body = res.getBody();
+  
+  const authToken = body.authorization;
+  const providerDataplanePublic = body.endpoint;
+  
+  bru.setEnvVar("protectedPullSecret", authToken);
+  bru.setEnvVar("PROVIDER_DATAPLANE_PUBLIC", providerDataplanePublic);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/InitPullTransfer.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/InitPullTransfer.bru
@@ -1,0 +1,41 @@
+meta {
+  name: InitPullTransfer
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{CONSUMER_MANAGEMENT}}/v3/transferprocesses
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{CONSUMER_MANAGEMENT_API_KEY}}
+}
+
+body:json {
+  {
+    "@context": {
+      "edc": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@type": "TransferRequestDto",
+    "protocol": "dataspace-protocol-http:2025-1",
+    "contractId": "{{protectedContractId}}",
+    "counterPartyAddress": "{{PROVIDER_ENDPOINT}}",
+    "connectorId": "{{DID_WEB_ID_PROVIDER}}",
+    "transferType": "HttpData-PULL"
+  }
+}
+
+script:post-response {
+  const transferId = res.getBody()['@id'];
+  bru.setEnvVar("protectedTransferId", transferId);
+  
+  await bru.sleep(2500);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/InitiateNegotiation.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/InitiateNegotiation.bru
@@ -1,0 +1,68 @@
+meta {
+  name: InitiateNegotiation
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{CONSUMER_MANAGEMENT}}/v3/contractnegotiations
+  body: json
+  auth: inherit
+}
+
+headers {
+  Accept: application/json
+  x-api-key: {{CONSUMER_MANAGEMENT_API_KEY}}
+}
+
+body:json {
+  {
+    "@context": [
+      "https://w3id.org/factoryx/policy/v1.0/context.jsonld",
+      "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+      {
+        "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      }
+    ],
+    "@type": "ContractRequest",
+    "counterPartyAddress": "{{PROVIDER_ENDPOINT}}",
+    "protocol": "dataspace-protocol-http:2025-1",
+    "policy": {
+      "@id": "{{protectedOfferId}}",
+      "@type": "Offer",
+      "assigner": "{{DID_WEB_ID_PROVIDER}}",
+      "permission": [],
+      "prohibition": [],
+      "obligation": [],
+      "target": "{{protectedAssetId}}"
+    },
+    "callbackAddresses": []
+  }
+}
+
+script:pre-request {
+  const permission = bru.getEnvVar("protectedOfferPermission");
+  
+  if (!permission) {
+    throw new Error("Missing protectedOfferPermission. Run RequestCatalog-WithMembership first.");
+  }
+  
+  const body = req.getBody();
+  body.policy.permission = JSON.parse(permission);
+  body.policy.prohibition = JSON.parse(bru.getEnvVar("protectedOfferProhibition") || "[]");
+  body.policy.obligation = JSON.parse(bru.getEnvVar("protectedOfferObligation") || "[]");
+  
+  req.setBody(body);
+}
+
+script:post-response {
+  var negotiationId = res.getBody()['@id'];
+  bru.setEnvVar("protectedNegotiationId", negotiationId);
+  
+  await bru.sleep(2500);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/PullAssetData.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/PullAssetData.bru
@@ -1,0 +1,20 @@
+meta {
+  name: PullAssetData
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{PROVIDER_DATAPLANE_PUBLIC}}
+  body: none
+  auth: inherit
+}
+
+script:pre-request {
+  req.setHeader("Authorization", bru.getEnvVar("protectedPullSecret"));
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/RequestCatalog-WithMembership.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/RequestCatalog-WithMembership.bru
@@ -1,0 +1,91 @@
+meta {
+  name: RequestCatalog-WithMembership
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{CONSUMER_MANAGEMENT}}/v3/catalog/request
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{CONSUMER_MANAGEMENT_API_KEY}}
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "counterPartyAddress": "{{PROVIDER_ENDPOINT}}",
+    "counterPartyId": "{{DID_WEB_ID_PROVIDER}}",
+    "protocol": "dataspace-protocol-http:2025-1",
+    "querySpec": {
+      "offset": 0,
+      "limit": 50,
+      "filterExpression": [
+        {
+          "operandLeft": "id",
+          "operator": "=",
+          "operandRight": "membership-gated-asset"
+        }
+      ]
+    }
+  }
+}
+
+script:post-response {
+  const clearNegotiationVars = () => {
+    bru.deleteEnvVar("protectedOfferId");
+    bru.deleteEnvVar("protectedAssetId");
+    bru.deleteEnvVar("protectedOfferPermission");
+    bru.deleteEnvVar("protectedOfferProhibition");
+    bru.deleteEnvVar("protectedOfferObligation");
+  };
+  
+  const body = res.getBody();
+  const dataset = body['dataset'];
+  const ds = Array.isArray(dataset) ? dataset[0] : dataset;
+  
+  if (!ds) {
+    clearNegotiationVars();
+    return;
+  }
+  
+  const policy = ds['hasPolicy'];
+  const offer = Array.isArray(policy) ? policy[0] : policy;
+  
+  if (!offer) {
+    clearNegotiationVars();
+    return;
+  }
+  
+  const target = ds['id'] || "membership-gated-asset";
+  
+  bru.setEnvVar("protectedOfferId", offer['@id']);
+  bru.setEnvVar("protectedAssetId", target);
+  bru.setEnvVar("protectedOfferPermission", JSON.stringify(offer['permission'] || []));
+  bru.setEnvVar("protectedOfferProhibition", JSON.stringify(offer['prohibition'] || []));
+  bru.setEnvVar("protectedOfferObligation", JSON.stringify(offer['obligation'] || []));
+}
+
+tests {
+  test("should return membership-gated asset with a negotiable offer", function () {
+    const body = res.getBody();
+    const dataset = body['dataset'];
+    const ds = Array.isArray(dataset) ? dataset[0] : dataset;
+    const policy = ds && (Array.isArray(ds['hasPolicy']) ? ds['hasPolicy'][0] : ds['hasPolicy']);
+  
+    expect(ds).to.exist;
+    expect(ds['id']).to.equal("membership-gated-asset");
+    expect(policy).to.exist;
+    expect(policy['@id']).to.exist;
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/folder.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/with credential/folder.bru
@@ -1,0 +1,22 @@
+meta {
+  name: with credential
+  seq: 3
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  This section demonstrates the positive case: the consumer requests the provider's catalog for an asset that requires a MembershipCredential.
+
+  During identity setup the consumer was issued a MembershipCredential by the trusted issuer. The provider's access policy for `membership-gated-asset` requires `Membership = active`. Because the consumer holds the correct credential, the asset appears in the catalog and the full negotiation and transfer flow succeeds.
+
+  Steps:
+  1. Request the catalog — the membership-gated asset is visible
+  2. Initiate contract negotiation using the offer from the catalog
+  3. Check the negotiation result — expect `FINALIZED`
+  4. Initiate a pull transfer
+  5. Retrieve the EDR (Endpoint Data Reference) with the authorization token
+  6. Pull the actual data using the EDR token
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/without credential/RequestCatalog-NoCertification.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/without credential/RequestCatalog-NoCertification.bru
@@ -1,0 +1,50 @@
+meta {
+  name: RequestCatalog-NoCertification
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{CONSUMER_MANAGEMENT}}/v3/catalog/request
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{CONSUMER_MANAGEMENT_API_KEY}}
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "counterPartyAddress": "{{PROVIDER_ENDPOINT}}",
+    "counterPartyId": "{{DID_WEB_ID_PROVIDER}}",
+    "protocol": "dataspace-protocol-http:2025-1",
+    "querySpec": {
+      "offset": 0,
+      "limit": 50,
+      "filterExpression": [
+        {
+          "operandLeft": "id",
+          "operator": "=",
+          "operandRight": "certification-gated-asset"
+        }
+      ]
+    }
+  }
+}
+
+tests {
+  test("should not return certification-gated asset if consumer lacks ISO9001 CertificationCredential", function () {
+    const body = res.getBody();
+    const dataset = body['dataset'];
+    expect(dataset).to.satisfy(d => !d || (Array.isArray(d) && d.length === 0));
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/without credential/folder.bru
+++ b/resources/bruno-fx-edc-idhub-collection/credential-gated transactions/without credential/folder.bru
@@ -1,0 +1,16 @@
+meta {
+  name: without credential
+  seq: 2
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  This section demonstrates the negative case: the consumer requests the provider's catalog for an asset that requires an ISO9001 CertificationCredential.
+
+  Since the consumer only holds a MembershipCredential (issued during identity setup) and does NOT have a CertificationCredential, the provider's access policy filters the asset from the catalog response.
+
+  Expected result: The catalog response contains no matching dataset for `certification-gated-asset`. The `dataset` array will be empty or absent.
+}

--- a/resources/bruno-fx-edc-idhub-collection/identities/folder.bru
+++ b/resources/bruno-fx-edc-idhub-collection/identities/folder.bru
@@ -1,6 +1,6 @@
 meta {
   name: identities
-  seq: 1
+  seq: 2
 }
 
 auth {

--- a/resources/bruno-fx-edc-idhub-collection/transactions/consumer/InitPullTransfer.bru
+++ b/resources/bruno-fx-edc-idhub-collection/transactions/consumer/InitPullTransfer.bru
@@ -31,6 +31,8 @@ body:json {
 script:post-response {
   const transferId = res.getBody()['@id'];
   bru.setEnvVar("transferId", transferId);
+  
+  await bru.sleep(2500);
 }
 
 settings {

--- a/resources/bruno-fx-edc-idhub-collection/transactions/consumer/InitiateNegotiation.bru
+++ b/resources/bruno-fx-edc-idhub-collection/transactions/consumer/InitiateNegotiation.bru
@@ -40,6 +40,8 @@ script:post-response {
   var x = res.getBody()['@id'];
   console.log("id " + x);
   bru.setEnvVar("negotiation-id", res.getBody()['@id']);
+  
+  await bru.sleep(2500);
 }
 
 settings {

--- a/resources/bruno-fx-edc-idhub-collection/transactions/folder.bru
+++ b/resources/bruno-fx-edc-idhub-collection/transactions/folder.bru
@@ -1,5 +1,6 @@
 meta {
   name: transactions
+  seq: 3
 }
 
 auth {

--- a/resources/local-fx-mvd/README.md
+++ b/resources/local-fx-mvd/README.md
@@ -65,6 +65,21 @@ are interested
 in a more detailed explanation of these interactions, please see
 the [EDC Samples](https://github.com/eclipse-edc/Samples/tree/main/transfer).
 
+### Credential-gated policy example
+
+The Bruno collection also includes a credential-gated policy section under `transactions`. This example demonstrates
+how access to provider assets can be restricted based on verifiable credentials held by the consumer.
+
+Two assets are created — one gated by a `MembershipCredential` (which the consumer holds) and one gated by an ISO9001
+`CertificationCredential` (which the consumer does not hold). The catalog request for the membership-gated asset
+succeeds, while the certification-gated asset is filtered out.
+
+> [!NOTE]
+> Run this example before the default transaction flow, or in a fresh environment. The default flow creates
+> a contract definition with an empty asset selector that would bypass the credential-gated access policies.
+
+For detailed instructions, see [Credential-Gated Policy Example](./credential-gated-policy.md).
+
 When you're done testing and want to end your session (using 'CTRL-C' on the terminal, where you started docker
 compose),
 you may want to run

--- a/resources/local-fx-mvd/credential-gated-policy.md
+++ b/resources/local-fx-mvd/credential-gated-policy.md
@@ -1,0 +1,78 @@
+# Credential-Gated Policy Example
+
+This is a simple example showing how Factory-X EDC policies can control access to assets based on credentials the consumer has.
+
+## How it works
+
+Policies are written in ODRL and checked by the provider's control plane. When a consumer asks for the catalog, the provider checks if the consumer has the right credentials for each asset. If not, the asset is hidden from the catalog.
+
+### Credentials used
+
+| Credential              | Left Operand      | Right Operand | Issued by default? |
+|-------------------------|-------------------|---------------|--------------------|
+| MembershipCredential    | FxMembership      | active        | Yes                |
+| CertificationCredential | CertificationType | ISO9001       | No                 |
+
+- If the consumer has a MembershipCredential, they can see and use the membership-gated asset.
+- If the consumer does not have a CertificationCredential, they can't see the certification-gated asset.
+
+## Policy Examples
+
+FxMembership Policy:
+
+```json
+{
+    "permission": {
+      "action": "use",
+      "constraint": {
+        "leftOperand": "https://w3id.org/factoryx/policy/v1.0/FxMembership",
+        "operator": "eq",
+        "rightOperand": "active"
+      }
+  }
+}
+```
+
+Certification Policy:
+
+```json
+{
+  "permission": {
+    "action": "use",
+    "constraint": {
+      "leftOperand": "CertificationType",
+      "operator": "eq",
+      "rightOperand": "ISO9001"
+    }
+  }
+}
+```
+
+Both policies are checked when showing the catalog and during contract negotiation.
+
+## Prerequisites
+
+> [!NOTE]
+> Run this example before the default transaction flow, or in a fresh environment (`docker compose down -v`).
+> The default flow's contract definition previously used an empty asset selector that would match all assets,
+> bypassing the credential-gated access policies.
+
+## Steps
+
+1. Start everything: `docker compose up`
+2. Run the identity setup requests (issuer, consumer, provider, credential issuance)
+3. Run the provider setup requests in order:
+   - CreateMembershipGatedAsset
+   - CreateCertificationGatedAsset
+   - CreateMembershipPolicy
+   - CreateCertificationPolicy
+   - CreateMembershipContractDef
+   - CreateCertificationContractDef
+4. Test without credential: run `RequestCatalog-NoCertification`. You shouldn't see the certification-gated asset.
+5. Test with credential: run `RequestCatalog-WithMembership`, then the negotiation and transfer steps. You should see the membership-gated asset and be able to transfer data.
+
+## Notes
+
+A third EDC for this example isn't required. The consumer already has MembershipCredential but not CertificationCredential, so you can see both allowed and denied cases.
+
+For more details, see the docs in the [EDC Management API Walkthrough](../../docs/usage/management-api-walkthrough/README.md).

--- a/resources/local-fx-mvd/docker-compose.yaml
+++ b/resources/local-fx-mvd/docker-compose.yaml
@@ -168,7 +168,7 @@ services:
 
   consumer-controlplane:
     container_name: consumer-controlplane
-    image: ghcr.io/factory-x-contributions/edc-controlplane-postgresql-hashicorp-vault:0.3.0-SNAPSHOT
+    image: ghcr.io/factory-x-contributions/edc-controlplane-postgresql-hashicorp-vault:0.4.0-SNAPSHOT
     pull_policy: missing
     environment:
       - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5005
@@ -218,7 +218,7 @@ services:
 
   consumer-dataplane:
     container_name: consumer-dataplane
-    image: ghcr.io/factory-x-contributions/edc-dataplane-hashicorp-vault:0.3.0-SNAPSHOT
+    image: ghcr.io/factory-x-contributions/edc-dataplane-hashicorp-vault:0.4.0-SNAPSHOT
     environment:
       - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5005
       - web.http.public.port=9500
@@ -264,7 +264,7 @@ services:
 
   provider-controlplane:
     container_name: provider-controlplane
-    image: ghcr.io/factory-x-contributions/edc-controlplane-postgresql-hashicorp-vault:0.3.0-SNAPSHOT
+    image: ghcr.io/factory-x-contributions/edc-controlplane-postgresql-hashicorp-vault:0.4.0-SNAPSHOT
     pull_policy: missing
     environment:
       - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5005
@@ -315,7 +315,7 @@ services:
 
   provider-dataplane:
     container_name: provider-dataplane
-    image: ghcr.io/factory-x-contributions/edc-dataplane-hashicorp-vault:0.3.0-SNAPSHOT
+    image: ghcr.io/factory-x-contributions/edc-dataplane-hashicorp-vault:0.4.0-SNAPSHOT
     environment:
       - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5005
       - web.http.public.port=9500


### PR DESCRIPTION
## WHAT

Adds an optional credential-gated policy example to the Bruno collection and local docker compose setup.

The new flow demonstrates two cases:

* a positive case where a membership-gated asset is visible, negotiable, and transferable because the consumer holds the required membership credential
* a negative case where an asset is filtered from the catalog because the consumer does not hold the required credential

## WHY

This makes the local setup more useful as a hands-on showcase for dataspace users by demonstrating how policies and credentials work together in practice across catalog visibility, negotiation, and transfer.

## FURTHER NOTES

Additional changes were included to support the example:

* added local documentation for the credential-gated scenario and a Management API walkthrough index
* aligned policy examples and scope extraction to consistently handle `FxMembership`
* updated related tests for membership credential resolution
* fixed the existing `CreateContractDefinition` Bruno request to use an explicit asset selector instead of a catch-all selector
* added small waits in Bruno negotiation and transfer steps to improve reliability in the local flow when used in a Bruno batch run (no manual delay has to be provided)
* updated local docker compose image versions used by the example to include the fix in `CredentialScopeExtractor`

Closes #418