### PR TITLE
docs: announce repository archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Factory-X EDC (Eclipse Dataspace Connector)
 
+> [!IMPORTANT]
+> **This repository is archived.** It will receive no further development or maintenance. Interested parties are invited to fork the repository and continue the work independently.
+
 [![Contributors][contributors-shield]][contributors-url]
 [![Stargazers][stars-shield]][stars-url]
 [![Apache 2.0 License][license-shield]][license-url]


### PR DESCRIPTION
Adds an archival notice to the README announcing that this repository will receive no further development and inviting interested parties to fork.